### PR TITLE
Highlight numbers on input focus

### DIFF
--- a/index.html
+++ b/index.html
@@ -35,6 +35,10 @@ button { padding: 0.5em 1em; margin-top: 1em; }
 let lastLat, lastLon;
 // Automatically focus the next field once the maximum length is reached
 document.querySelectorAll('.dms-input input').forEach(inp => {
+    inp.addEventListener('focus', e => {
+        e.target.select();
+    });
+
     inp.addEventListener('input', e => {
         const max = e.target.getAttribute('maxlength');
         if (max && e.target.value.length >= max) {


### PR DESCRIPTION
## Summary
- highlight the entire contents of latitude and longitude fields when they gain focus

## Testing
- `python3 -m http.server 8000`

------
https://chatgpt.com/codex/tasks/task_e_688b500335848321809c63def2fc3ff0