### PR TITLE
Round coordinates for Google Maps

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,8 @@ the fixed latitude north and longitude west values.
 
 After converting, you can also open the decimal coordinates directly in
 Google Maps using the new "Open in Google Maps" button.
+Both the displayed coordinates and the link use four decimal places of
+precision.
 
 ### Running locally
 

--- a/index.html
+++ b/index.html
@@ -69,7 +69,7 @@ function convert() {
 
 function openMap() {
     if (typeof lastLat !== 'undefined' && typeof lastLon !== 'undefined') {
-        const url = `https://www.google.com/maps?q=${lastLat},${lastLon}`;
+        const url = `https://www.google.com/maps?q=${lastLat.toFixed(4)},${lastLon.toFixed(4)}`;
         window.open(url, '_blank');
     }
 }


### PR DESCRIPTION
## Summary
- round coordinates passed to Google Maps so links match the shown decimal
- document that four decimal places are used

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_688b5114b5c48321b3a7e9494f40e122